### PR TITLE
Compatibility with GHC 8.4 (Monoid/Semigroup proposal)

### DIFF
--- a/src/Data/Binary/BitBuilder.hs
+++ b/src/Data/Binary/BitBuilder.hs
@@ -37,6 +37,7 @@ module Data.Binary.BitBuilder (
 
 import Foreign hiding (unsafePerformIO)
 import Data.Monoid
+import Data.Semigroup (Semigroup((<>)))
 import qualified Data.ByteString      as S
 import qualified Data.ByteString.Lazy as L
 import System.IO.Unsafe (unsafePerformIO)
@@ -79,6 +80,9 @@ newtype BitBuilder = BitBuilder {
 
 instance Show BitBuilder where
   show = const "<BitBuilder>"
+
+instance Semigroup BitBuilder where
+  (<>) = append
 
 instance Monoid BitBuilder where
     mempty  = empty


### PR DESCRIPTION
Adds compatibility with GHC 8.4 by providing Semigroup instance to BitBuilder (Semigroup as a superclass of Monoid Proposal https://ghc.haskell.org/trac/ghc/ticket/10365)