### PR TITLE
Add GHC 8.8 support

### DIFF
--- a/binary-strict.cabal
+++ b/binary-strict.cabal
@@ -34,7 +34,7 @@ library
                        FlexibleInstances,
                        MultiParamTypeClasses,
                        UndecidableInstances
-  build-depends:       base >=4.12 && <4.13,
+  build-depends:       base >=4.12 && <4.15,
                        bytestring >=0.10 && <0.11,
                        mtl >=2.2 && <2.3,
                        array >=0.5 && <0.6
@@ -44,7 +44,7 @@ library
 Test-Suite test
     type:              exitcode-stdio-1.0
     main-is:           tests/BitGetTest.hs
-    build-depends:     base >=4.12 && <4.13,
+    build-depends:     base >=4.12 && <4.15,
                        bytestring >=0.10 && <0.11,
                        binary-strict
     default-language:  Haskell2010

--- a/src/Data/Binary/Strict/BitGet.hs
+++ b/src/Data/Binary/Strict/BitGet.hs
@@ -95,7 +95,15 @@ instance Monad BitGet where
   m >>= k = BitGet (\s -> case unGet m s of
                             (Left err, s') -> (Left err, s')
                             (Right a, s') -> unGet (k a) s')
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(8,8,0,0)
+
+instance MonadFail BitGet where
   fail err = BitGet (\s -> (Left err, s))
+#else
+  fail err = BitGet (\s -> (Left err, s))
+#endif
+#endif
 
 -- | Run a BitGet on a ByteString
 runBitGet :: B.ByteString -> BitGet a -> Either String a

--- a/src/Data/Binary/Strict/Class.hs
+++ b/src/Data/Binary/Strict/Class.hs
@@ -4,15 +4,15 @@
 --   -fno-monomorphism-restriction is very useful.
 module Data.Binary.Strict.Class where
 
-import Control.Applicative (Alternative, (<|>))
+import           Control.Applicative (Alternative, (<|>))
 
-import qualified Data.ByteString as B
-import Data.Word
+import qualified Data.ByteString     as B
+import           Data.Word
 
 -- | This is the generic class for the set of binary parsers. This lets you
 --   write parser functions which are agnostic about the pattern of parsing
 --   in which they get used (incremental, strict, bitwise etc)
-class (Monad m, Alternative m) => BinaryParser m where
+class (Monad m, MonadFail m, Alternative m) => BinaryParser m where
   skip :: Int -> m ()
   bytesRead :: m Int
   remaining :: m Int
@@ -60,7 +60,7 @@ class (Monad m, Alternative m) => BinaryParser m where
     result <- many p
     case result of
          [] -> fail ""
-         x -> return x
+         x  -> return x
 
   optional :: m a -> m (Maybe a)
   optional p = (p >>= return . Just) <|> return Nothing

--- a/src/Data/Binary/Strict/Class.hs
+++ b/src/Data/Binary/Strict/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- | This module contains a single class which abstracts over Get and
 --   IncrementalGet, so that one can write parsers which work in both.
 --   If you are using this module, you may find that
@@ -12,7 +13,13 @@ import           Data.Word
 -- | This is the generic class for the set of binary parsers. This lets you
 --   write parser functions which are agnostic about the pattern of parsing
 --   in which they get used (incremental, strict, bitwise etc)
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(8,8,0,0)
 class (Monad m, MonadFail m, Alternative m) => BinaryParser m where
+#else
+class (Monad m, Alternative m) => BinaryParser m where
+#endif
+#endif
   skip :: Int -> m ()
   bytesRead :: m Int
   remaining :: m Int

--- a/src/Data/Binary/Strict/Get.hs
+++ b/src/Data/Binary/Strict/Get.hs
@@ -116,7 +116,15 @@ instance Monad Get where
   m >>= k = Get (\s -> case unGet m s of
                             (Left err, s') -> (Left err, s')
                             (Right a, s') -> unGet (k a) s')
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(8,8,0,0)
+
+instance MonadFail Get where
   fail err = Get (\s -> (Left err, s))
+#else
+  fail err = Get (\s -> (Left err, s))
+#endif
+#endif
 
 get :: Get S
 get = Get (\s -> (Right s, s))

--- a/src/Data/Binary/Strict/IncrementalGet.hs
+++ b/src/Data/Binary/Strict/IncrementalGet.hs
@@ -143,7 +143,15 @@ instance Functor (Get r) where
 instance Monad (Get r) where
   return a = Get (\s -> \k -> k a s)
   m >>= k = Get (\s -> \cont -> unGet m s (\a -> \s' -> unGet (k a) s' cont))
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(8,8,0,0)
+
+instance MonadFail (Get r) where
   fail err = Get (\s -> const $ IFailed s err)
+#else
+  fail err = Get (\s -> const $ IFailed s err)
+#endif
+#endif
 
 get :: Get r S
 get = Get (\s -> \k -> k s s)


### PR DESCRIPTION
Hi @idontgetoutmuch! 

Could you please take a look on this pull request?

- Since GHC 8.8 `fail` was cut of `Monad` type class.
- In this PR implemented conditional compilation with backward compatibility for GHC < 8.8.

Thanks,
@swamp-agr